### PR TITLE
feature : empMapper 추가 (#47)

### DIFF
--- a/workforus/src/main/java/site/workforus/forus/mapper/EmpMapper.java
+++ b/workforus/src/main/java/site/workforus/forus/mapper/EmpMapper.java
@@ -1,0 +1,9 @@
+package site.workforus.forus.mapper;
+
+import site.workforus.forus.employee.model.EmpDTO;
+
+public interface EmpMapper {
+	public EmpDTO selectEmployee(EmpDTO empDto);
+
+	public int insertEmployee(EmpDTO empDto);
+}

--- a/workforus/src/main/resources/mybatis/mapper/empMapper.xml
+++ b/workforus/src/main/resources/mybatis/mapper/empMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="site.workforus.forus.mapper.EmpMapper">
+	<resultMap type="empDto" id="empDtoMap">
+		<result property="empId" column="emp_id" />
+		<result property="empNm" column="emp_nm"/>
+		<result property="empPw" column="emp_pw"/>
+		<result property="empCheckPw" column="emp_check_pw"/>
+		<result property="empEmail" column="emp_email"/>
+		<result property="empAssistEmail" column="emp_assist_email"/>
+	</resultMap>
+	<insert id="insertEmployee" parameterType="empDto">
+		INSERT INTO 
+			TB_EMPLOYEES(emp_id
+					   , emp_nm
+					   , emp_pw
+					   , emp_check_pw
+					   , emp_email
+					   , emp_assist_email) 
+				  VALUES(#{empId}
+				       , #{empNm}
+				       , #{empPw}
+				       , #{empCheckPw}
+				       , #{empEmail}
+				       , #{empAssistEmail})
+	</insert>
+
+	<select id="selectEmployee" parameterType="empDto" resultMap="empDtoMap">
+		SELECT emp_id
+			 , emp_nm
+			 , emp_pw
+			 , emp_check_pw
+			 , emp_email
+			 , emp_assist_email
+		  FROM TB_EMPLOYEES
+		 WHERE emp_id = #{empId}
+	</select>
+	
+</mapper>

--- a/workforus/src/main/resources/mybatis/mybatis-config.xml
+++ b/workforus/src/main/resources/mybatis/mybatis-config.xml
@@ -8,6 +8,7 @@
 	
 	<typeAliases>
 		<!-- Employee -->
+		<package name="site.workforus.forus.employee.model"/>
 		
 		<!-- Department & Job -->
 		<package name="site.workforus.forus.dept.model"/>


### PR DESCRIPTION
## 🚀 PR 개요
<!-- PR 간략 설명 -->
- tb_employees table에 연결할 empMapper를 추가하였다.

## 🔗 관련 이슈
- resolved: #47 

## 💻 작업 내용
> 구현/수정 작업 내용들을 구체적으로 적어주세요.
<!-- 메인 페이지의 lazy loading을 ~을 이용하여 구현하였다. 등 -->
- EmpMapper에 service와 연결할 로직을 구현하였다.
- empMapper에 로그인 시 tb_employees 조회와 회원가입 시 tb_employees 에 추가하는 로직을 구현하였다.

## 🎁 성장 Point
> 기능 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.
- interface를 통한 mapper 연결 방식을 알게 되었다.

