### PR TITLE
feature : 캘린더 페이지에 로그인된 유저 정보 적용 및 캘린더, 일정 공유 (#152)

### DIFF
--- a/workforus/src/main/java/site/workforus/forus/calendar/controller/CalendarController.java
+++ b/workforus/src/main/java/site/workforus/forus/calendar/controller/CalendarController.java
@@ -2,7 +2,9 @@ package site.workforus.forus.calendar.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,11 +15,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import lombok.extern.slf4j.Slf4j;
 import site.workforus.forus.calendar.model.CalendarDTO;
 import site.workforus.forus.calendar.model.CalendarShareDTO;
 import site.workforus.forus.calendar.service.CalendarService;
 import site.workforus.forus.calendar.service.CalendarShareService;
+import site.workforus.forus.employee.model.LoginVO;
 
+@Slf4j
 @Controller
 @RequestMapping(value = "/calendar")
 public class CalendarController {
@@ -29,7 +34,16 @@ public class CalendarController {
 	CalendarShareService calendarShareService;
 
 	@GetMapping(value = "")
-	public String getPage() {
+	public String getPage(Model model, Authentication auth) {
+
+		LoginVO loginVO = (LoginVO) auth.getPrincipal();
+
+		log.info("loginData={}", loginVO.getUsername());
+
+		String empId = loginVO.getUsername();
+
+		model.addAttribute("empId", empId);
+
 		return "calendar/calendar";
 	}
 
@@ -39,6 +53,15 @@ public class CalendarController {
 
 		ResponseEntity<Object> datas = empId == null ? calendarService.selectAll()
 				: calendarService.selectByEmpId(empId);
+
+		return datas;
+	}
+
+	@ResponseBody
+	@GetMapping(value = "/recent")
+	public ResponseEntity<Object> getRecentCalendar(@RequestParam(value = "empId", required = true) String empId) {
+
+		ResponseEntity<Object> datas = calendarService.selectRecendDate(empId);
 
 		return datas;
 	}
@@ -59,7 +82,6 @@ public class CalendarController {
 		ResponseEntity<Object> datas = calendarService.addCalendar(calendarDTO);
 
 		return datas;
-
 	}
 
 	@ResponseBody
@@ -121,6 +143,14 @@ public class CalendarController {
 	public ResponseEntity<Object> deleteCalendarShare(@PathVariable("calShrId") int calShrId) {
 
 		var datas = calendarShareService.deleteCalendarShare(calShrId);
+
+		return datas;
+	}
+
+	@ResponseBody
+	@GetMapping(value = "/share/emp-list")
+	public ResponseEntity<Object> getEmpList() {
+		ResponseEntity<Object> datas = calendarShareService.getEmpList();
 
 		return datas;
 	}

--- a/workforus/src/main/java/site/workforus/forus/calendar/service/CalendarService.java
+++ b/workforus/src/main/java/site/workforus/forus/calendar/service/CalendarService.java
@@ -81,6 +81,18 @@ public class CalendarService {
 		return res;
 	}
 
+	public ResponseEntity<Object> selectRecendDate(String empId) {
+		CalendarMapper mapper = session.getMapper(CalendarMapper.class);
+
+		List<CalendarDTO> datas = mapper.selectRecentData(empId);
+
+		ResponseDTO<List<CalendarDTO>> result = new ResponseDTO<>("SUCCESS", 200, datas);
+
+		ResponseEntity<Object> res = new ResponseEntity<>(result, HttpStatus.OK);
+
+		return res;
+	}
+
 	public ResponseEntity<Object> updateCalendar(CalendarDTO calendarDTO) {
 		CalendarMapper mapper = session.getMapper(CalendarMapper.class);
 

--- a/workforus/src/main/java/site/workforus/forus/calendar/service/CalendarShareService.java
+++ b/workforus/src/main/java/site/workforus/forus/calendar/service/CalendarShareService.java
@@ -12,8 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import site.workforus.forus.calendar.model.CalendarShareDTO;
+import site.workforus.forus.employee.model.EmpDTO;
 import site.workforus.forus.global.dto.ResponseDTO;
 import site.workforus.forus.mapper.CalendarShareMapper;
+import site.workforus.forus.mapper.EmpMapper;
 
 @Service
 public class CalendarShareService {
@@ -126,6 +128,24 @@ public class CalendarShareService {
 			result = new ResponseDTO<>("FAIL", 400, "캘린더 공유 삭제에 실패하였습니다.", json);
 			res = new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
 		}
+
+		return res;
+	}
+
+	public ResponseEntity<Object> getEmpList() {
+		EmpMapper empMapper = session.getMapper(EmpMapper.class);
+
+		List<EmpDTO> datas = empMapper.selectEmployeeAll();
+
+		Map<String, String> map = new HashMap<>();
+
+		datas.stream().forEach(data -> {
+			map.put(data.getEmpId(), data.getEmpNm());
+		});
+
+		ResponseDTO<Map<String, String>> result = new ResponseDTO<>("SUCCESS", 200, map);
+
+		ResponseEntity<Object> res = new ResponseEntity<>(result, HttpStatus.OK);
 
 		return res;
 	}

--- a/workforus/src/main/java/site/workforus/forus/mapper/CalendarMapper.java
+++ b/workforus/src/main/java/site/workforus/forus/mapper/CalendarMapper.java
@@ -14,6 +14,8 @@ public interface CalendarMapper {
 
 	public List<CalendarDTO> selectByCalId(int calId);
 
+	public List<CalendarDTO> selectRecentData(String empId);
+
 	public boolean updateData(CalendarDTO calendarDTO);
 
 	public boolean deleteById(int calId);

--- a/workforus/src/main/resources/mybatis/mapper/calendarMapper.xml
+++ b/workforus/src/main/resources/mybatis/mapper/calendarMapper.xml
@@ -46,6 +46,17 @@
 		SELECT * FROM TB_CALENDARS WHERE EMP_ID = #{empId}
 	</select>
 	
+	<select id="selectRecentData" parameterType="string" resultMap="calendarDtoMap">
+		<![CDATA[
+		SELECT * FROM 
+			(SELECT * FROM 
+				TB_CALENDARS 
+				WHERE EMP_ID=#{empId} 
+				ORDER BY CAL_ID desc) 
+		WHERE ROWNUM  < = 1
+		]]>
+	</select>
+	
 
 	<delete id="deleteById">
 		DELETE FROM TB_CALENDARS

--- a/workforus/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
+++ b/workforus/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
@@ -22,6 +22,7 @@ pageEncoding="UTF-8"%>
   </head>
 
   <body>
+  	<script type="text/javascript">const empId = "${empId}"</script>
     <%@ include file="../module/navigation.jsp" %>
     <div id="app">
       <div id="main">
@@ -43,6 +44,8 @@ pageEncoding="UTF-8"%>
     <script type="text/babel" src="static/js/pages/calendar/modal/ModalPortal.js"></script>
     <script type="text/babel" src="static/js/pages/calendar/modal/AddCalendarFrame.js"></script>
     <script type="text/babel" src="static/js/pages/calendar/modal/AddCalendarModal.js"></script>
+    <script type="text/babel" src="static/js/pages/calendar/modal/AddShareCalendarFrame.js"></script>
+    <script type="text/babel" src="static/js/pages/calendar/modal/AddShareCalendarModal.js"></script>
     <script type="text/babel" src="static/js/pages/calendar/modal/AddScheduleFrame.js"></script>
     <script type="text/babel" src="static/js/pages/calendar/modal/AddScheduleModal.js"></script>
     <script type="text/babel" src="static/js/pages/calendar/modal/CalendarInfoFrame.js"></script>

--- a/workforus/src/main/webapp/resources/css/pages/calendar.css
+++ b/workforus/src/main/webapp/resources/css/pages/calendar.css
@@ -200,3 +200,10 @@
 	font-size: 1.3rem;
 }
 
+.cal-add-icon {
+	margin-top: 100px;
+}
+
+.col-icon-wrapper {
+	width: 15px;
+}

--- a/workforus/src/main/webapp/resources/js/pages/calendar/App.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/App.js
@@ -4,11 +4,11 @@ const App = () => {
   const [onModal, setOnModal] = React.useState(false);
 
   const [onInfoModal, setOnInfoModal] = React.useState(false);
-  
+
   const [calendarInfoModal, setCalendarInfoModal] = React.useState(false);
 
   const [eventInfo, setEventInfo] = React.useState();
-  
+
   const [calendarInfo, setCalendarInfo] = React.useState();
 
   const [myCal, setMyCal] = React.useState([]);
@@ -18,8 +18,6 @@ const App = () => {
   const [mySche, setMySche] = React.useState([]);
 
   const [shareSche, setShareSche] = React.useState([]);
-
-  const empId = "A2022100";
 
   let calendarList = [];
 
@@ -76,12 +74,34 @@ const App = () => {
   }, []);
 
   React.useEffect(() => {
+    shareCal.forEach((cal) => {
+      axios
+        .get(`http://localhost/schedule?calId=${cal.calId}`)
+        .then((res) => {
+          const schedules = res.data.data;
+          setShareSche(schedules);
+
+          return schedules;
+        })
+        .then((schedules) => {
+          schedules.forEach((sche) => {
+            const newEvent = eventConverter(sche);
+            calendarRef.current.getInstance().createEvents([newEvent]);
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    });
+  }, [shareCal]);
+
+  React.useEffect(() => {
     const myCalendar = myCal.map((item) => {
       return { id: item.calId, name: item.calName };
     });
 
     const shareCalendar = shareCal.map((item) => {
-      return { id: item.calId, name: item.calName };
+      return { id: item.calId, name: item.calendarDTO.calName };
     });
 
     calendarList = [...myCalendar, ...shareCalendar];
@@ -95,11 +115,20 @@ const App = () => {
     calendarRef.current.getInstance().createEvents([newEvent]);
   };
 
-  const addCalendar = (cal) => {
-  	axios
+  const addCalendar = () => {
+    axios
       .get(`http://localhost/calendar/list?empId=${empId}`)
       .then((res) => {
         setMyCal(res.data.data);
+      })
+      .catch();
+  };
+
+  const addShareCalendar = () => {
+    axios
+      .get(`http://localhost/calendar/share?empId=${empId}`)
+      .then((res) => {
+        setShareCal(res.data.data.calendarDTO);
       })
       .catch();
   };
@@ -145,29 +174,29 @@ const App = () => {
       .getInstance()
       .setCalendarVisibility(String(event.target.name), event.target.checked);
   };
-  
+
   const onUpdateEvent = (event) => {
-  	calendarRef.current.getInstance().updateEvent(event.id, event.calendarId,{
-  		title: event.title,
-  		body: event.body,
-  		start: event.start,
-  		end: event.end,
-  		isAllday: event.isAllday
-  	});
-  }
-  
+    calendarRef.current.getInstance().updateEvent(event.id, event.calendarId, {
+      title: event.title,
+      body: event.body,
+      start: event.start,
+      end: event.end,
+      isAllday: event.isAllday,
+    });
+  };
+
   const onDeleteEvent = (event) => {
-  	calendarRef.current.getInstance().deleteEvent(event.id, event.calendarId);
-  }
+    calendarRef.current.getInstance().deleteEvent(event.id, event.calendarId);
+  };
 
   return (
     <div id="calendar-wrapper" className="row match-height container">
       <CalendarMenu
         myCal={myCal}
         shareCal={shareCal}
-        addCalendar={(cal) => addCalendar(cal)}
+        addCalendar={addCalendar}
+        addShareCalendar={addShareCalendar}
         checkCalendarVisibilitiy={checkCalendarVisibilitiy}
-        setOnModal={(bool) => setOnModal(bool)}
         setCalendarInfoModal={(bool) => setCalendarInfoModal(bool)}
         setCalendarInfo={(cal) => setCalendarInfo(cal)}
       />
@@ -196,11 +225,11 @@ const App = () => {
         />
       )}
       {calendarInfoModal && (
-      	<CalendarInfoModal
-      		calendarInfo={calendarInfo}
-      		setCalendarInfoModal={(bool) => setCalendarInfoModal(bool)}
-        	addCalendar={(cal) => addCalendar(cal)}
-      	/>
+        <CalendarInfoModal
+          calendarInfo={calendarInfo}
+          setCalendarInfoModal={(bool) => setCalendarInfoModal(bool)}
+          addCalendar={(cal) => addCalendar(cal)}
+        />
       )}
     </div>
   );

--- a/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarMenu.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarMenu.js
@@ -24,13 +24,17 @@ const CalendarMenu = (props) => {
             menuName="내 캘린더"
             subMenu={props.myCal}
             addCalendar={props.addCalendar}
-        	setCalendarInfoModal={props.setCalendarInfoModal}
-        	setCalendarInfo={props.setCalendarInfo}
+            setCalendarInfoModal={props.setCalendarInfoModal}
+            setCalendarInfo={props.setCalendarInfo}
             checkCalendarVisibilitiy={props.checkCalendarVisibilitiy}
           />
           <CalendarSubShareMenu
             menuName="공유 캘린더"
             subMenu={props.shareCal}
+            addCalendar={props.addShareCalendar}
+            setCalendarInfo={props.setCalendarInfo}
+            setCalendarInfoModal={props.setCalendarInfoModal}
+            checkCalendarVisibilitiy={props.checkCalendarVisibilitiy}
           />
         </ul>
       </div>

--- a/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarSubMenu.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarSubMenu.js
@@ -1,16 +1,23 @@
 const CalendarSubMenu = (props) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [onModal, setOnModal] = React.useState(false);
-  const [isChecked, setIsChecked] = React.useState(true);
 
   const toggleSubMenu = () => {
     setIsOpen((isOpen) => !isOpen);
   };
-  
+
   const onClickCalendarName = (item) => {
-	props.setCalendarInfo(item);
-	props.setCalendarInfoModal(true);
-  }
+    props.setCalendarInfo(item);
+    props.setCalendarInfoModal(true);
+  };
+
+  const onClickAdd = () => {
+    setOnModal(true);
+  };
+
+  const onClickClose = () => {
+    setOnModal(false);
+  };
 
   return (
     <li className="sidebar-item has-sub">
@@ -18,37 +25,42 @@ const CalendarSubMenu = (props) => {
         <span>{props.menuName}</span>
       </div>
       <ul className={isOpen ? "submenu" : "submenu hide-menu"}>
-        {props.subMenu &&
-          props.subMenu.map((item) => (
-            <li className="submenu-item" key={item.calId}>
+        {props.subMenu.map((item) => (
+          <li className="submenu-item row" key={item.calId}>
+            <label
+              className="form-check-label col"
+              tagname={item.calId}
+              value={item.calId}
+              onClick={() => onClickCalendarName(item)}
+            >
+              {item.calName}
+            </label>
+            <div className="col-4">
               <input
                 className="form-check-input"
                 type="checkbox"
                 id="flexCheckDefault"
                 name={item.calId}
-                onClick={(event)=>{props.checkCalendarVisibilitiy(event)}}
+                onClick={(event) => {
+                  props.checkCalendarVisibilitiy(event);
+                }}
                 defaultChecked
               />
-              <label className="form-check-label" tagname={item.calId} value={item.calId} onClick={()=>onClickCalendarName(item)}>
-                {item.calName}
-              </label>
-            </li>
-          ))}
-        <li className="submenu-item">
-          <i className="bi bi-plus-square"></i>
-          <label
-            className="form-check-label"
-            onClick={() => setOnModal(true)}
-          >
-            추가하기
-          </label>
-          {onModal && (
-            <AddCalendarModal
-              setOnModal={(bool) => setOnModal(bool)}
-              addCalendar={props.addCalendar}
-            />
-          )}
+            </div>
+          </li>
+        ))}
+        <li className="submenu-item row" onClick={onClickAdd}>
+          <label className="form-check-label col">추가하기</label>
+          <div className="col-4 mt-1">
+            <i className="bi bi-plus-square cal-add-icon"></i>
+          </div>
         </li>
+        {onModal && (
+          <AddCalendarModal
+            onClickClose={onClickClose}
+            addCalendar={props.addCalendar}
+          />
+        )}
       </ul>
     </li>
   );

--- a/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarSubShareMenu.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/components/CalendarSubShareMenu.js
@@ -6,6 +6,15 @@ const CalendarSubShareMenu = (props) => {
     setIsOpen((isOpen) => !isOpen);
   };
 
+  const onClickCalendarName = (item) => {
+    props.setCalendarInfo(item);
+    props.setCalendarInfoModal(true);
+  };
+
+  const onSetModal = () => {
+    setOnModal((prev) => !prev);
+  };
+
   return (
     <li className="sidebar-item has-sub">
       <div className="sidebar-link" onClick={toggleSubMenu}>
@@ -13,29 +22,41 @@ const CalendarSubShareMenu = (props) => {
       </div>
       <ul className={isOpen ? "submenu" : "submenu hide-menu"}>
         {props.subMenu.map((item) => (
-          <li className="submenu-item" key={item.calShrId}>
-            <input
-              className="form-check-input"
-              type="checkbox"
-              value=""
-            />
-            <label className="form-check-label">
+          <li className="submenu-item row" key={item.calShrId}>
+            <label
+              className="form-check-label col"
+              tagname={item.calendarDTO.calId}
+              value={item.calendarDTO.calId}
+              onClick={() => onClickCalendarName(item)}
+            >
               {item.calendarDTO.calName}
             </label>
+            <div className="col-4">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="flexCheckDefault"
+                name={item.calId}
+                onClick={(event) => {
+                  props.checkCalendarVisibilitiy(event);
+                }}
+                defaultChecked
+              />
+            </div>
           </li>
         ))}
-        <li className="submenu-item">
-          <i className="bi bi-plus-square"></i>
-          <label
-            className="form-check-label"
-            onClick={() => setOnModal(true)}
-          >
-            추가하기
-          </label>
-          {onModal && (
-            <AddCalendarModal setOnModal={(bool) => setOnModal(bool)} />
-          )}
+        <li className="submenu-item row" onClick={onSetModal}>
+          <label className="form-check-label col">추가하기</label>
+          <div className="col-4 mt-1">
+            <i className="bi bi-plus-square cal-add-icon"></i>
+          </div>
         </li>
+        {onModal && (
+          <AddShareCalendarModal
+            onClose={onSetModal}
+            addShareCalendar={props.addShareCalendar}
+          />
+        )}
       </ul>
     </li>
   );

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddCalendarModal.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddCalendarModal.js
@@ -1,8 +1,7 @@
 const AddCalendarModal = (props) => {
-  console.log(props.addCalendar);
   return (
     <AddCalendarFrame
-      setOnModal={props.setOnModal}
+      onClickClose={props.onClickClose}
       addCalendar={props.addCalendar}
     />
   );

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddScheduleFrame.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddScheduleFrame.js
@@ -1,6 +1,6 @@
 const AddScheduleFrame = (props) => {
   const [inputs, setInputs] = React.useState({
-    empId: "A2022100",
+    empId: empId,
     calId: null,
     scheName: null,
     scheContent: null,
@@ -81,8 +81,8 @@ const AddScheduleFrame = (props) => {
                 <i data-feather="x" className="bi bi-x fs-5"></i>
               </button>
             </div>
-            <form action="#">
-              <div className="modal-body">
+            <div className="modal-body overflow-scroll">
+              <form action="#">
                 <label>캘린더 선택</label>
                 <select
                   className="form-select"
@@ -152,9 +152,7 @@ const AddScheduleFrame = (props) => {
                     onChange={onCheckBoxChange}
                     onBlur={onCheckBoxBlur}
                   />
-                  <label className="form-check-label">
-                    종일 여부
-                  </label>
+                  <label className="form-check-label">종일 여부</label>
                 </div>
                 {inputs.scheAlltime === "N" && (
                   <React.Fragment>
@@ -181,26 +179,26 @@ const AddScheduleFrame = (props) => {
                     </div>
                   </React.Fragment>
                 )}
-              </div>
-              <div className="modal-footer">
-                <button
-                  type="button"
-                  className="btn btn-light-secondary"
-                  onClick={() => props.setOnModal(false)}
-                >
-                  <i className="bx bx-x d-block d-sm-none"></i>
-                  <span className="d-none d-sm-block">닫기</span>
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-primary ml-1"
-                  onClick={onSubmit}
-                >
-                  <i className="bx bx-check d-block d-sm-none"></i>
-                  <span className="d-none d-sm-block">등록</span>
-                </button>
-              </div>
-            </form>
+              </form>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-light-secondary"
+                onClick={() => props.setOnModal(false)}
+              >
+                <i className="bx bx-x d-block d-sm-none"></i>
+                <span className="d-none d-sm-block">닫기</span>
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary ml-1"
+                onClick={onSubmit}
+              >
+                <i className="bx bx-check d-block d-sm-none"></i>
+                <span className="d-none d-sm-block">등록</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddShareCalendarFrame.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddShareCalendarFrame.js
@@ -1,0 +1,161 @@
+const AddShareCalendarFrame = (props) => {
+  const [userList, setUserList] = React.useState([]);
+
+  const [searchOption, setSearchOption] = React.useState("0");
+
+  const [user, setUser] = React.useState();
+
+  const [calendarList, setCalendarList] = React.useState([]);
+
+  React.useEffect(() => {
+    axios
+      .get("http://localhost/calendar/share/emp-list")
+      .then((res) => {
+        setUserList(res.data.data);
+      })
+      .catch();
+  });
+
+  const onSelect = (event) => {
+    setSearchOption(event.target.value);
+  };
+
+  const onChangeUser = (event) => {
+    setUser(event.target.value);
+  };
+
+  const onSearchUser = (event) => {
+    event.preventDefault();
+    let empNo, empName, isExist;
+    if (searchOption === "0") {
+      empNo = Object.keys(userList).find((key) => userList[key] === user);
+      if (empNo) {
+        isExist = true;
+        empName = user;
+      }
+    } else {
+      isExist = Object.keys(userList).includes(user);
+      if (isExist) {
+        empNo = user;
+        empName = userList[empNo];
+      }
+    }
+    axios.get(`http://localhost/calendar/list?empId=${empNo}`).then((res) => {
+      const filteredList = res.data.data.filter(
+        (calendar) => calendar.calAccess !== "0"
+      );
+      setCalendarList(filteredList);
+    });
+    if (!isExist) alert("존재하지 않는 직원입니다.");
+  };
+
+  const onAddCalendar = (event) => {
+    event.preventDefault();
+    console.log(event.target.value);
+    axios
+      .post("http://localhost/calendar/share", {
+        empId: empId,
+        calId: event.target.value,
+      })
+      .then((res) => {
+        if (res.data.result === "SUCCESS")
+          alert("캘린더 추가에 성공하셨습니다.");
+        else alert("캘린더 추가에 실패하셨습니다.");
+      });
+  };
+
+  return (
+    <ModalPortal>
+      <div
+        className="modal fade text-left show"
+        id="inlineForm"
+        tabIndex="-1"
+        aria-modal="true"
+        role="dialog"
+        style={{ display: "block" }}
+      >
+        <div className="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h4 className="modal-title">공유 캘린더 추가</h4>
+              <button
+                type="button"
+                className="close"
+                onClick={props.onClose}
+              >
+                <i data-feather="x" className="bi bi-x fs-5"></i>
+              </button>
+            </div>
+            <div className="modal-body">
+              <form action="#">
+                <label>캘린더 생성자 검색: </label>
+                <div className="form-group">
+                  <div className="row g-3">
+                    <div className="col-auto">
+                      <select
+                        className="form-select"
+                        value={searchOption}
+                        onChange={onSelect}
+                      >
+                        <option value="0">이름</option>
+                        <option value="1">사번</option>
+                      </select>
+                    </div>
+                    <div className="col-auto">
+                      <input
+                        type="text"
+                        className="form-control"
+                        onChange={onChangeUser}
+                      />
+                    </div>
+                    <div className="col-auto">
+                      <button
+                        className="btn btn-outline-secondary"
+                        onClick={onSearchUser}
+                      >
+                        검색하기
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  {calendarList.length !== 0 &&
+                    calendarList.map((calendar) => {
+                      return (
+                        <div key={calendar.calId} className="mt-3">
+                          <div className="row g-3">
+                            <div className="col-5">
+                              <div className="mt-2">{calendar.calName}</div>
+                            </div>
+                            <div className="col-5">
+                              <button
+                                className="btn btn-light-secondary"
+                                value={calendar.calId}
+                                onClick={onAddCalendar}
+                              >
+                                추가하기
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              </form>
+            </div>
+            <div className="modal-footer mt-3">
+              <button
+                type="button"
+                className="btn btn-light-secondary"
+                onClick={props.onClose}
+              >
+                <i className="bx bx-x d-block d-sm-none"></i>
+                <span className="d-none d-sm-block">닫기</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+};

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddShareCalendarModal.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/AddShareCalendarModal.js
@@ -1,0 +1,3 @@
+const AddShareCalendarModal = (props) => {
+  return <AddShareCalendarFrame onClose={props.onClose} />;
+};

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/CalendarInfoFrame.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/CalendarInfoFrame.js
@@ -1,12 +1,12 @@
 const CalendarInfoFrame = (props) => {
   const [checks, setChecks] = React.useState([false, false, false]);
   const [inputs, setInputs] = React.useState(props.calendarInfo);
-  
-  React.useEffect(()=>{
-  	const newChecks = Array.from(checks);
-  	newChecks[+props.calendarInfo.calAccess]=true;
-  	setChecks(newChecks);
-  },[props.calendarInfo]);
+
+  React.useEffect(() => {
+    const newChecks = Array.from(checks);
+    newChecks[+props.calendarInfo.calAccess] = true;
+    setChecks(newChecks);
+  }, [props.calendarInfo]);
 
   const onInputChange = (event) => {
     setInputs({ ...inputs, [event.target.name]: event.target.value });
@@ -27,25 +27,27 @@ const CalendarInfoFrame = (props) => {
           alert("캘린더 생성에 성공하였습니다.");
         }
         props.setCalendarInfoModal(false);
-      }).then((res)=>{
-	    props.addCalendar(inputs);      	
+      })
+      .then((res) => {
+        props.addCalendar(inputs);
       })
       .catch();
   };
-  
+
   const onClickDelete = (event) => {
-   axios.delete(`http://localhost/calendar/list/${inputs.calId}`)
-   	.then((res)=> {
-   		if (res.data.result === "FAIL") 
-          alert("캘린더 삭제에 실패하였습니다.");
-        else 
-          alert("캘린더 삭제에 성공하였습니다.");
-     return res;
-   	}).then((res)=>{
+    axios
+      .delete(`http://localhost/calendar/list/${inputs.calId}`)
+      .then((res) => {
+        if (res.data.result === "FAIL") alert("캘린더 삭제에 실패하였습니다.");
+        else alert("캘린더 삭제에 성공하였습니다.");
+        return res;
+      })
+      .then((res) => {
         props.setCalendarInfoModal(false);
-	    props.addCalendar(inputs);   	
-   	}).catch();
-  }
+        props.addCalendar(inputs);
+      })
+      .catch();
+  };
 
   return (
     <ModalPortal onClick={() => props.setOnModal(false)}>
@@ -64,13 +66,13 @@ const CalendarInfoFrame = (props) => {
               <button
                 type="button"
                 className="close"
-                 onClick={() => props.setCalendarInfoModal(false)}
+                onClick={() => props.setCalendarInfoModal(false)}
               >
-                <i data-feather="x" className="bi bi-x fs-5" ></i>
+                <i data-feather="x" className="bi bi-x fs-5"></i>
               </button>
             </div>
-            <form action="#">
-              <div className="modal-body">
+            <div className="modal-body">
+              <form action="#">
                 <label>캘린더 제목: </label>
                 <div className="form-group">
                   <input
@@ -123,20 +125,24 @@ const CalendarInfoFrame = (props) => {
                     전체 공개
                   </label>
                 </div>
-              </div>
-              <div className="modal-footer">
-                <button type="button" className="btn btn-alert ml-1" onClick={onClickDelete}>
-                  <span className="d-none d-sm-block">삭제하기</span>
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-light-secondary"
-                  onClick={() => props.setCalendarInfoModal(false)}
-                >
-                  <span className="d-none d-sm-block">닫기</span>
-                </button>
-              </div>
-            </form>
+              </form>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-alert ml-1"
+                onClick={onClickDelete}
+              >
+                <span className="d-none d-sm-block">삭제하기</span>
+              </button>
+              <button
+                type="button"
+                className="btn btn-light-secondary"
+                onClick={() => props.setCalendarInfoModal(false)}
+              >
+                <span className="d-none d-sm-block">닫기</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/workforus/src/main/webapp/resources/js/pages/calendar/modal/ScheduleInfoFrame.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/modal/ScheduleInfoFrame.js
@@ -1,11 +1,10 @@
 const ScheduleInfoFrame = (props) => {
   const [inputs, setInputs] = React.useState(props.eventInfo);
 
-  React.useEffect(()=>{
-  if(props.eventInfo !== null)
-  	setInputs(eventReverter(props.eventInfo));
-  },[props.eventInfo]);
-  
+  React.useEffect(() => {
+    if (props.eventInfo !== null) setInputs(eventReverter(props.eventInfo));
+  }, [props.eventInfo]);
+
   const onInputChange = (event) => {
     setInputs({ ...inputs, [event.target.name]: event.target.value });
   };
@@ -33,33 +32,37 @@ const ScheduleInfoFrame = (props) => {
       setInputs({ ...inputs, [scheTimeStart]: null, [scheTimeEnd]: null });
     }
   };
-  
+
   const onClickUpdate = () => {
-  	axios.put("http://localhost/schedule", inputs).
-  	then((res)=>{
-  		if(res.data.result === "FAIL") {
-  			alert("일정 수정에 실패하였습니다.");
-  		} else {
-  			alert("일정 수정에 성공하였습니다.");
-  		}
-  	}).catch((e)=>console.error(e));
-  	props.onUpdateEvent(eventConverter(inputs));
-  	props.setOnInfoModal(false)
-  }
-  
+    axios
+      .put("http://localhost/schedule", inputs)
+      .then((res) => {
+        if (res.data.result === "FAIL") {
+          alert("일정 수정에 실패하였습니다.");
+        } else {
+          alert("일정 수정에 성공하였습니다.");
+        }
+      })
+      .catch((e) => console.error(e));
+    props.onUpdateEvent(eventConverter(inputs));
+    props.setOnInfoModal(false);
+  };
+
   const onClickDelete = () => {
-  	axios.delete(`http://localhost/schedule/${inputs.scheId}`).
-  	then((res)=>{
-  		if(res.data.result === "FAIL") {
-  			alert("일정 삭제에 실패하였습니다.");
-  		} else {
-  			alert("일정 삭제에 성공하였습니다.");
-  		}
-  	}).catch((e)=>console.error(e));
+    axios
+      .delete(`http://localhost/schedule/${inputs.scheId}`)
+      .then((res) => {
+        if (res.data.result === "FAIL") {
+          alert("일정 삭제에 실패하였습니다.");
+        } else {
+          alert("일정 삭제에 성공하였습니다.");
+        }
+      })
+      .catch((e) => console.error(e));
     props.onDeleteEvent(eventConverter(inputs));
-  	props.setOnInfoModal(false)
-  }
-  
+    props.setOnInfoModal(false);
+  };
+
   return (
     <ModalPortal onClick={() => props.setOnInfoModal(false)}>
       <div
@@ -82,8 +85,8 @@ const ScheduleInfoFrame = (props) => {
                 <i data-feather="x" className="bi bi-x fs-5"></i>
               </button>
             </div>
-            <form action="#">
-              <div className="modal-body">
+            <div className="modal-body">
+              <form action="#">
                 <label>캘린더</label>
                 <select
                   value={inputs.calId}
@@ -92,7 +95,11 @@ const ScheduleInfoFrame = (props) => {
                   name="calId"
                 >
                   {props.myCal.map((cal) => {
-                    return <option key={cal.calId} value={cal.calId}>{cal.calName}</option>;
+                    return (
+                      <option key={cal.calId} value={cal.calId}>
+                        {cal.calName}
+                      </option>
+                    );
                   })}
                 </select>
                 <label>일정 제목: </label>
@@ -124,7 +131,9 @@ const ScheduleInfoFrame = (props) => {
                     type="date"
                     name="scheDateStart"
                     className="form-control"
-                    defaultValue={dayjs(inputs.scheDateStart).format('YYYY-MM-DD')}
+                    defaultValue={dayjs(inputs.scheDateStart).format(
+                      "YYYY-MM-DD"
+                    )}
                     onChange={onDateChange}
                     onBlur={onDateChange}
                   />
@@ -145,17 +154,15 @@ const ScheduleInfoFrame = (props) => {
                 <div className="form-check">
                   <input
                     className="form-check-input"
-                    name="scheAllday"
+                    name="scheAlltime"
                     type="checkbox"
                     onChange={onCheckBoxChange}
                     onBlur={onCheckBoxBlur}
-                    checked={inputs.scheAllday === "Y" ? true : false}
+                    checked={inputs.scheAlltime === "Y" ? true : false}
                   />
-                  <label className="form-check-label">
-                    종일 여부
-                  </label>
+                  <label className="form-check-label">종일 여부</label>
                 </div>
-                {inputs.scheAllday === "N" && (
+                {inputs.scheAlltime !== "Y" && (
                   <React.Fragment>
                     <label>일정 시작 시간: </label>
                     <div className="form-group">
@@ -163,7 +170,7 @@ const ScheduleInfoFrame = (props) => {
                         type="time"
                         name="scheTimeStart"
                         className="form-control"
-                    	defaultValue={inputs.scheTimeStart}
+                        defaultValue={inputs.scheTimeStart}
                         onChange={onInputChange}
                         onBlur={onInputBlur}
                       />
@@ -175,30 +182,38 @@ const ScheduleInfoFrame = (props) => {
                         type="time"
                         name="scheTimeEnd"
                         className="form-control"
-                    	defaultValue={inputs.scheTimeEnd}
+                        defaultValue={inputs.scheTimeEnd}
                         onChange={onInputChange}
                         onBlur={onInputBlur}
                       />
                     </div>
                   </React.Fragment>
                 )}
-              </div>
-              <div className="modal-footer">
-                <button
-                  type="button"
-                  className="btn btn-light-secondary"
-                  onClick={() => props.setOnInfoModal(false)}
-                >
-                  <span className="d-none d-sm-block">닫기</span>
-                </button>
-                <button type="button" className="btn btn-alert ml-1" onClick={onClickDelete}>
-                  <span className="d-none d-sm-block">삭제하기</span>
-                </button>
-                <button type="button" className="btn btn-primary ml-1" onClick={onClickUpdate}>
-                  <span className="d-none d-sm-block">수정하기</span>
-                </button>
-              </div>
-            </form>
+              </form>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-light-secondary"
+                onClick={() => props.setOnInfoModal(false)}
+              >
+                <span className="d-none d-sm-block">닫기</span>
+              </button>
+              <button
+                type="button"
+                className="btn btn-alert ml-1"
+                onClick={onClickDelete}
+              >
+                <span className="d-none d-sm-block">삭제하기</span>
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary ml-1"
+                onClick={onClickUpdate}
+              >
+                <span className="d-none d-sm-block">수정하기</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/workforus/src/main/webapp/resources/js/pages/calendar/utils/eventReverter.js
+++ b/workforus/src/main/webapp/resources/js/pages/calendar/utils/eventReverter.js
@@ -7,8 +7,8 @@ const eventReverter = (event) => {
       scheName: event.title,
       scheContent: event.body,
       scheAlltime: "Y",
-      scheDateStart: dayjs(event.start.d.d).format('YYYY-MM-DD'),
-      scheDateEnd: dayjs(event.end.d.d).format('YYYY-MM-DD'),
+      scheDateStart: dayjs(event.start.d.d).format("YYYY-MM-DD"),
+      scheDateEnd: dayjs(event.end.d.d).format("YYYY-MM-DD"),
       scheTimeStart: null,
       scheTimeEnd: null,
     };
@@ -19,11 +19,16 @@ const eventReverter = (event) => {
       scheName: event.title,
       scheContent: event.body,
       scheAlltime: "N",
-      scheDateStart: dayjs(event.start.d.d).format('YYYY-MM-DD'),
-      scheDateEnd: dayjs(event.end.d.d).format('YYYY-MM-DD'),
+      scheDateStart: dayjs(event.start.d.d).format("YYYY-MM-DD"),
+      scheDateEnd: dayjs(event.end.d.d).format("YYYY-MM-DD"),
       scheTimeStart:
-        event.start.d.d.getHours() + ":" + event.start.d.d.getMinutes(),
-      scheTimeEnd: event.end.d.d.getHours() + ":" + event.end.d.d.getMinutes(),
+        new String(event.start.d.d.getHours()).padStart(2, 0) +
+        ":" +
+        new String(event.start.d.d.getMinutes()).padStart(2, 0),
+      scheTimeEnd:
+        new String(event.end.d.d.getHours()).padStart(2, 0) +
+        ":" +
+        new String(event.end.d.d.getMinutes()).padStart(2, 0),
     };
   }
   console.log(schedule);


### PR DESCRIPTION
## 🚀 PR 개요
<!-- PR 간략 설명 -->
- 캘린더 페이지에 로그인된 유저 정보 적용 및 캘린더, 일정 공유 기능 추가

## 🔗 관련 이슈
- resolved: #152 

## 💻 작업 내용
> 구현/수정 작업 내용들을 구체적으로 적어주세요.
<!-- 메인 페이지의 lazy loading을 ~을 이용하여 구현하였다. 등 -->
- 캘린더 페이지에 로그인된 유저 정보가 적용되도록 하였습니다.
- 캘린더 생성 시 유저를 검색하여 공유할 수 있도록 하였습니다.
- 유저를 검색하여 그 유저가 공유 가능하도록 생성한 캘린더를 공유 캘린더에 수정할 수 있도록 하였습니다.
- 캘린더 체크박스의 위치를 변경하였습니다.
- 캘린더의 정보를 확인할때 체크박스에 선택이 제대로 되어있지 않았던 점과 특정 시간대의 경우 나타나지 않던 것을 수정하였습니다.
